### PR TITLE
Add Datadog Exporter for Probes

### DIFF
--- a/hal/exporters/base.py
+++ b/hal/exporters/base.py
@@ -5,7 +5,7 @@ class BaseExporter(object):
 
     def __init__(self, config=None):
         config = config or {}
-        self.config = {**BaseExporter.DEFAULTS, **config}
+        self.config = {**self.DEFAULTS, **config}
 
     def send(self, data):
         """Send must be implemented in the child class to define how data is serialized

--- a/hal/exporters/datadog.py
+++ b/hal/exporters/datadog.py
@@ -1,0 +1,40 @@
+import datadog
+import logging
+
+from .base import BaseExporter
+
+
+log = logging.getLogger(__name__)
+
+
+class DatadogExporter(BaseExporter):
+    """DatadogExporter sends data to Datadog API. Every kwarg in the results dictionary
+    is used as a metric name, so the naming of your keys is important. As example, if
+    the result dictionary is ``{"hal.metric": 42}`` the exporter sends a metric
+    named ``hal.metric``.
+    """
+
+    DEFAULTS = {"api_key": None, "hostname": None, "tags": None}
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        datadog.initialize(api_key=self.config["api_key"])
+
+    def send(self, data):
+        if self.config["api_key"] is None:
+            log.error("DatadogExporter: api_key is not configured.")
+            return
+
+        for k, v in data.items():
+            response = datadog.api.Metric.send(
+                host=self.config["hostname"],
+                tags=self.config["tags"],
+                metric=k,
+                points=v,
+            )
+
+            if response.get("status") != "ok":
+                log.error(
+                    "DatadogExporter: unable to send metric. Server response was '%s'",
+                    response,
+                )

--- a/hal/probes/parsec.py
+++ b/hal/probes/parsec.py
@@ -36,8 +36,8 @@ class ParsecProbe(BaseProbe):
         if response.status_code == 200:
             json_resp = response.json()
             self.results = {
-                "play_time": json_resp["play_time"],
-                "credits": json_resp["credits"],
+                "hal.parsec.play_time": json_resp["play_time"],
+                "hal.parsec.credits": json_resp["credits"],
             }
             return True
         else:

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,2 @@
+datadog
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
+datadog==0.29.3
+decorator==4.4.0          # via datadog
 idna==2.8                 # via requests
 requests==2.22.0
 urllib3==1.25.3           # via requests

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,7 +1,9 @@
+import datadog
 import logging
 import pytest
 
 from hal.exporters.base import BaseExporter
+from hal.exporters.datadog import DatadogExporter
 from hal.exporters.logger import LogExporter
 
 
@@ -21,3 +23,62 @@ def test_log_exporter(caplog):
         for record in caplog.records:
             assert record.levelname == "INFO"
             assert record.message == "42"
+
+
+def test_datadog_exporter_client_config(mocker):
+    """Should configure Datadog client with the given API_KEY."""
+    mocker.patch("datadog.initialize")
+    DatadogExporter({"api_key": "test_api_key"})
+    assert datadog.initialize.call_count == 1
+    assert datadog.initialize.call_args == ({"api_key": "test_api_key"},)
+
+
+def test_datadog_exporter_missing_api_key(caplog):
+    """Should log an error if the API_KEY is not configured."""
+    with caplog.at_level(logging.ERROR):
+        exporter = DatadogExporter()
+        exporter.send(42)
+
+        assert len(caplog.records) == 1
+        for record in caplog.records:
+            assert record.levelname == "ERROR"
+            assert "api_key is not configured" in record.message
+
+
+def test_datadog_exporter_send(mocker):
+    """Should send probe data to Datadog."""
+    mocker.patch("datadog.api.Metric.send").return_value = {"status": "ok"}
+    exporter = DatadogExporter(
+        {"api_key": "valid", "hostname": "home", "tags": "automation"}
+    )
+    exporter.send({"metric_1": 1, "metric_2": 2})
+
+    # Two different metrics must be sent
+    assert datadog.api.Metric.send.call_count == 2
+    _, kwargs = datadog.api.Metric.send.call_args_list[0]
+    assert kwargs == {
+        "host": "home",
+        "metric": "metric_1",
+        "points": 1,
+        "tags": "automation",
+    }
+    _, kwargs = datadog.api.Metric.send.call_args_list[1]
+    assert kwargs == {
+        "host": "home",
+        "metric": "metric_2",
+        "points": 2,
+        "tags": "automation",
+    }
+
+
+def test_datadog_exporter_send_fail(mocker, caplog):
+    """Should log an error if the response is not a 200."""
+    mocker.patch("datadog.api.Metric.send").return_value = {"status": "error"}
+    with caplog.at_level(logging.ERROR):
+        exporter = DatadogExporter({"api_key": "valid"})
+        exporter.send({"metric_1": 1})
+
+        assert len(caplog.records) == 1
+        for record in caplog.records:
+            assert record.levelname == "ERROR"
+            assert "unable to send metric" in record.message

--- a/tests/test_probe_parsec.py
+++ b/tests/test_probe_parsec.py
@@ -63,8 +63,8 @@ def test_parsec_success(server):
     probe = ParsecProbe({"session_id": "valid"})
     probe.run()
     assert len(probe.results) == 2
-    assert probe.results["play_time"] == 5000
-    assert probe.results["credits"] == 100
+    assert probe.results["hal.parsec.play_time"] == 5000
+    assert probe.results["hal.parsec.credits"] == 100
 
 
 def test_parsec_fail(server, caplog):

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,9 @@ envlist =
 setenv =
     PYTHONPATH = {toxinidir}
     PYTHONDONTWRITEBYTECODE=1
-deps = -r requirements/requirements-testing.txt
+deps =
+     -r requirements.txt
+     -r requirements/requirements-testing.txt
 commands =
     pytest tests/ --cov hal -s
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
      -r requirements.txt
      -r requirements/requirements-testing.txt
 commands =
-    pytest tests/ --cov hal -s
+    pytest tests/ --cov hal -s -v
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
### Overview

Closes #3 

`DatadogExporter` allows to send `Probe` data to Datadog. It expects results to be in the format of:
```python
{"metric_name": value}
```

In that case, a metric is sent directly to Datadog API, with `metric_name` as name and `value` as value.

### Configuration

Available options are:
```python
DEFAULTS = {"api_key": None, "hostname": None, "tags": None}
```
`api_key` is mandatory and the exporter will not run without it.