### PR TITLE
[probe] Add WatchdogProbe to detect connected devices 

### DIFF
--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -1,2 +1,3 @@
 from .parsec import entrypoint as parsec_probe  # noqa
+from .watchdog import entrypoint as watchdog_probe  # noqa
 from .paperspace import entrypoint as paperspace_probe  # noqa

--- a/functions/watchdog.py
+++ b/functions/watchdog.py
@@ -1,0 +1,35 @@
+from os import getenv
+
+from hal.probes.watchdog import WatchdogProbe
+from hal.exporters.datadog import DatadogExporter
+
+
+def entrypoint(event, context):
+    """Function entrypoint that uses a WatchdogProbe to see if a list
+    of hosts are reachable.
+
+    Environment variables configuration:
+      * `DD_API_KEY`: Datadog API key.
+      * `DD_HOSTNAME` (default `hal`): Hostname used for the Datadog metric.
+      * `WATCHDOG_HOSTS` (default `[]`): List of hostnames or IP addresses to check
+      * `WATCHDOG_TAGS` (default `None`): Add tags to all Datadog metrics.
+
+    Args:
+         event (dict): Event payload.
+         context (google.cloud.functions.Context): Metadata for the event.
+    """
+    config = {
+        "hosts": getenv("WATCHDOG_HOSTS", "").split(),
+        "exporters": [
+            DatadogExporter(
+                {
+                    "api_key": getenv("DD_API_KEY"),
+                    "hostname": getenv("DD_HOSTNAME", "hal"),
+                    "tags": getenv("WATCHDOG_TAGS"),
+                }
+            )
+        ],
+    }
+    probe = WatchdogProbe(config)
+    probe.run()
+    probe.export()

--- a/hal/probes/watchdog.py
+++ b/hal/probes/watchdog.py
@@ -1,0 +1,43 @@
+import logging
+import subprocess
+
+from .base import BaseProbe
+
+
+log = logging.getLogger(__name__)
+
+
+class WatchdogProbe(BaseProbe):
+    """WatchdogProbe Probe detects if a list of hosts are connected to the
+    probe network. This probe requires a list of hosts address:
+        * ["127.0.0.1"]
+        * ["192.168.1.1", "test-server"]
+
+    Under the hood, `WatchdogProbe` uses `ping` sending a single packet and
+    checking the return code. `subprocess` is used
+    The Probe collects the following metrics:
+        * Number of connected hosts from the given list
+    """
+
+    DEFAULTS = {
+        "hosts": [],
+    }
+
+    def _run(self):
+        if not self.config["hosts"]:
+            # Bail out if hosts are not defined
+            return False, "run failed for missing hosts to monitor"
+
+        # Metric: number of detected hosts
+        self.results["hal.watchdog.detected_hosts"] = 0
+
+        for host in self.config["hosts"]:
+            # Ping the host to check if present in the network
+            process = subprocess.run(["ping", "-c", "1", host], capture_output=True)
+            if process.returncode == 0:
+                self.results["hal.watchdog.detected_hosts"] += 1
+            else:
+                # Keep debug information with `ping` stdout
+                log.debug("Probe watchdog: host '%s' not found", host)
+
+        return True, None

--- a/tests/test_probe_watchdog.py
+++ b/tests/test_probe_watchdog.py
@@ -1,0 +1,60 @@
+import logging
+
+from hal.probes.watchdog import WatchdogProbe
+
+
+def test_watchdog_probe():
+    """Should be initialized with a default config."""
+    probe = WatchdogProbe()
+    assert probe.config["hosts"] == []
+
+
+def test_watchdog_run_without_hosts(caplog):
+    """Should fail if hosts are not defined."""
+    probe = WatchdogProbe()
+    with caplog.at_level(logging.ERROR):
+        result = probe.run()
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "ERROR"
+        assert "run failed for missing hosts" in record.message
+        assert result is False
+
+
+def test_watchdog_success():
+    """Should succeed with valid hosts to monitor."""
+    probe = WatchdogProbe({"hosts": ["127.0.0.1"]})
+    probe.run()
+    assert len(probe.results) == 1
+    assert probe.results["hal.watchdog.detected_hosts"] == 1
+
+
+def test_watchdog_multiple_hosts():
+    """Should detect multiple hosts."""
+    probe = WatchdogProbe({"hosts": ["127.0.0.1", "127.0.0.1"]})
+    probe.run()
+    assert len(probe.results) == 1
+    assert probe.results["hal.watchdog.detected_hosts"] == 2
+
+
+def test_watchdog_partial_failure():
+    """Should report only detected hosts."""
+    probe = WatchdogProbe({"hosts": ["127.0.0.1", "invalid-host"]})
+    probe.run()
+    assert len(probe.results) == 1
+    assert probe.results["hal.watchdog.detected_hosts"] == 1
+
+
+def test_watchdog_failure(caplog):
+    """Should log a debug entry if it fails."""
+    probe = WatchdogProbe({"hosts": ["invalid-host"]})
+    with caplog.at_level(logging.DEBUG):
+        result = probe.run()
+
+        assert len(caplog.records) == 3
+        record = caplog.records[1]
+        assert record.levelname == "DEBUG"
+        assert "Probe watchdog: host 'invalid-host' not found" in record.message
+        assert result is True
+        assert probe.results["hal.watchdog.detected_hosts"] == 0

--- a/tests/test_probe_watchdog.py
+++ b/tests/test_probe_watchdog.py
@@ -1,3 +1,4 @@
+import pytest
 import logging
 
 from hal.probes.watchdog import WatchdogProbe
@@ -22,32 +23,52 @@ def test_watchdog_run_without_hosts(caplog):
         assert result is False
 
 
-def test_watchdog_success():
+def test_watchdog_success(mocker):
     """Should succeed with valid hosts to monitor."""
+    process = mocker.patch("subprocess.run")
+    process.return_value.returncode = 0
     probe = WatchdogProbe({"hosts": ["127.0.0.1"]})
     probe.run()
     assert len(probe.results) == 1
     assert probe.results["hal.watchdog.detected_hosts"] == 1
 
 
-def test_watchdog_multiple_hosts():
+def test_watchdog_multiple_hosts(mocker):
     """Should detect multiple hosts."""
+    process = mocker.patch("subprocess.run")
+    process.return_value.returncode = 0
     probe = WatchdogProbe({"hosts": ["127.0.0.1", "127.0.0.1"]})
     probe.run()
     assert len(probe.results) == 1
     assert probe.results["hal.watchdog.detected_hosts"] == 2
 
 
-def test_watchdog_partial_failure():
+def test_watchdog_partial_failure(mocker):
     """Should report only detected hosts."""
+    process = mocker.patch("subprocess.run")
+    type(process.return_value).returncode = mocker.PropertyMock(side_effect=[0, 1])
     probe = WatchdogProbe({"hosts": ["127.0.0.1", "invalid-host"]})
     probe.run()
     assert len(probe.results) == 1
     assert probe.results["hal.watchdog.detected_hosts"] == 1
 
 
-def test_watchdog_failure(caplog):
+@pytest.mark.xfail
+def test_watchdog_partial_failure_integration(mocker):
+    """Should report only detected hosts. This test runs the `ping` command,
+    but in some CI it can fail to prevent DoS. Because of that, the test
+    is marked as it can fail.
+    """
+    probe = WatchdogProbe({"hosts": ["127.0.0.1", "invalid-host"]})
+    probe.run()
+    assert len(probe.results) == 1
+    assert probe.results["hal.watchdog.detected_hosts"] == 1
+
+
+def test_watchdog_failure(caplog, mocker):
     """Should log a debug entry if it fails."""
+    process = mocker.patch("subprocess.run")
+    process.return_value.returncode = 1
     probe = WatchdogProbe({"hosts": ["invalid-host"]})
     with caplog.at_level(logging.DEBUG):
         result = probe.run()


### PR DESCRIPTION
### Overview

Add `WatchdogProbe` that uses `ping` to detect if a list of devices are reachable from the probe. This function is not meant to be used in a cloud, but rather in a local network where devices are recognized with static IP addresses.

### Configuration
The probe requires the following environment variables to work properly:
* `DD_API_KEY`: a valid Datadog API key
* `WATCHDOG_HOSTS`: a list of hosts written in the format `127.0.0.1 test-server something-else`

Optional configs:
* `DD_HOSTNAME`: the hostname to use as a tag, unless `hal` is not the right one
* `WATCHDOG_TAGS`: a list of tags to use in Datadog metrics

### Reported Metrics
The function reports the following metrics to Datadog:
* `hal.watchdog.detected_hosts`: number of detected devices from the 