### PR TITLE
Add ElmoProbe to collect the status of an Elmo System

### DIFF
--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -1,3 +1,4 @@
+from .elmo import entrypoint as elmo_probe  # noqa
 from .parsec import entrypoint as parsec_probe  # noqa
 from .watchdog import entrypoint as watchdog_probe  # noqa
 from .paperspace import entrypoint as paperspace_probe  # noqa

--- a/functions/elmo.py
+++ b/functions/elmo.py
@@ -1,0 +1,38 @@
+from os import getenv
+
+from hal.probes.elmo import ElmoProbe
+from hal.exporters.datadog import DatadogExporter
+
+
+def entrypoint(event, context):
+    """Function entrypoint that uses a WatchdogProbe to see if a list
+    of hosts are reachable.
+
+    Environment variables configuration:
+      * `DD_API_KEY`: Datadog API key.
+      * `DD_HOSTNAME` (default `hal`): Hostname used for the Datadog metric.
+      * `WATCHDOG_HOSTS` (default `[]`): List of hostnames or IP addresses to check
+      * `WATCHDOG_TAGS` (default `None`): Add tags to all Datadog metrics.
+
+    Args:
+         event (dict): Event payload.
+         context (google.cloud.functions.Context): Metadata for the event.
+    """
+    config = {
+        "base_url": getenv("ELMO_BASE_URL"),
+        "vendor": getenv("ELMO_VENDOR"),
+        "username": getenv("ELMO_USERNAME"),
+        "password": getenv("ELMO_PASSWORD"),
+        "exporters": [
+            DatadogExporter(
+                {
+                    "api_key": getenv("DD_API_KEY"),
+                    "hostname": getenv("DD_HOSTNAME", "hal"),
+                    "tags": getenv("ELMO_TAGS"),
+                }
+            )
+        ],
+    }
+    probe = ElmoProbe(config)
+    probe.run()
+    probe.export()

--- a/hal/probes/elmo.py
+++ b/hal/probes/elmo.py
@@ -1,6 +1,7 @@
 import logging
 
 from elmo.api.client import ElmoClient
+from requests.exceptions import HTTPError
 
 from .base import BaseProbe
 
@@ -29,9 +30,12 @@ class ElmoProbe(BaseProbe):
             return False, "run failed for missing credentials"
 
         # Access Elmo and get the system status
-        client = ElmoClient(self.config["base_url"], self.config["vendor"])
-        client.auth(self.config["username"], self.config["password"])
-        status = client.check()
+        try:
+            client = ElmoClient(self.config["base_url"], self.config["vendor"])
+            client.auth(self.config["username"], self.config["password"])
+            status = client.check()
+        except HTTPError as e:
+            return False, "run failed. ElmoClient returns '{}'".format(e)
 
         # Metrics: collect armed/disarmed areas and system inputs status
         self.results["hal.elmo.areas"] = []

--- a/hal/probes/elmo.py
+++ b/hal/probes/elmo.py
@@ -1,0 +1,58 @@
+import logging
+
+from elmo.api.client import ElmoClient
+
+from .base import BaseProbe
+
+
+log = logging.getLogger(__name__)
+
+
+class ElmoProbe(BaseProbe):
+    """TODO
+    """
+
+    DEFAULTS = {
+        "base_url": None,
+        "vendor": None,
+        "username": None,
+        "password": None,
+    }
+
+    def _run(self):
+        if not self.config["base_url"] or not self.config["vendor"]:
+            # Bail out if the Elmo endpoint is not defined
+            return False, "run failed for missing 'base_url' and 'vendor' endpoint"
+
+        if not self.config["username"] or not self.config["password"]:
+            # Bail out if credentials are not defined
+            return False, "run failed for missing credentials"
+
+        # Access Elmo and get the system status
+        client = ElmoClient(self.config["base_url"], self.config["vendor"])
+        client.auth(self.config["username"], self.config["password"])
+        status = client.check()
+
+        # Metrics: collect armed/disarmed areas and system inputs status
+        self.results["hal.elmo.areas"] = []
+        self.results["hal.elmo.inputs"] = []
+
+        # Collect metrics
+        for item in status["areas_armed"]:
+            self.results["hal.elmo.areas"].append(
+                (1, ["name:{}".format(item["name"]), "status:armed"])
+            )
+        for item in status["areas_disarmed"]:
+            self.results["hal.elmo.areas"].append(
+                (1, ["name:{}".format(item["name"]), "status:disarmed"])
+            )
+        for item in status["inputs_alerted"]:
+            self.results["hal.elmo.inputs"].append(
+                (1, ["name:{}".format(item["name"]), "status:alerted"])
+            )
+        for item in status["inputs_wait"]:
+            self.results["hal.elmo.inputs"].append(
+                (1, ["name:{}".format(item["name"]), "status:wait"])
+            )
+
+        return True, None

--- a/main.py
+++ b/main.py
@@ -1,3 +1,3 @@
 """Google Cloud Functions entrypoint. List here all your functions."""
 
-from functions import parsec_probe, paperspace_probe
+from functions import parsec_probe, paperspace_probe, elmo_probe

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 datadog
 requests
+git+https://github.com/palazzem/elmo-alerting.git@0.2.0#elmo-alerting

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,18 @@
 #
 #    pip-compile requirements.in
 #
+beautifulsoup4==4.8.1
 certifi==2019.9.11        # via requests
+cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
+cryptography==2.8         # via pyopenssl, requests
 datadog==0.31.0
 decorator==4.4.1          # via datadog
+git+https://github.com/palazzem/elmo-alerting.git@0.2.0#elmo-alerting
 idna==2.8                 # via requests
-requests==2.22.0
+pycparser==2.19           # via cffi
+pyopenssl==19.0.0         # via requests
+requests[security]==2.22.0
+six==1.13.0               # via cryptography, pyopenssl
+soupsieve==1.9.5          # via beautifulsoup4
 urllib3==1.25.7           # via requests

--- a/tests/test_probe_elmo.py
+++ b/tests/test_probe_elmo.py
@@ -1,0 +1,119 @@
+import logging
+
+from requests.exceptions import HTTPError
+
+from hal.probes.elmo import ElmoProbe
+
+
+def test_elmo_probe():
+    """Should be initialized with a default config."""
+    probe = ElmoProbe()
+    assert probe.config["base_url"] is None
+    assert probe.config["vendor"] is None
+    assert probe.config["username"] is None
+    assert probe.config["password"] is None
+
+
+def test_elmo_without_base_url(caplog):
+    """Should fail if base_url is not defined."""
+    probe = ElmoProbe()
+    with caplog.at_level(logging.ERROR):
+        result = probe.run()
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "ERROR"
+        assert "missing 'base_url' and 'vendor'" in record.message
+        assert result is False
+
+
+def test_elmo_without_vendor(caplog):
+    """Should fail if vendor is not defined."""
+    probe = ElmoProbe({"base_url": "https://example.com"})
+    with caplog.at_level(logging.ERROR):
+        result = probe.run()
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "ERROR"
+        assert "missing 'base_url' and 'vendor'" in record.message
+        assert result is False
+
+
+def test_elmo_without_username(caplog):
+    """Should fail if username is not defined."""
+    probe = ElmoProbe({"base_url": "https://example.com", "vendor": "vendor"})
+    with caplog.at_level(logging.ERROR):
+        result = probe.run()
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "ERROR"
+        assert "missing credentials" in record.message
+        assert result is False
+
+
+def test_elmo_without_password(caplog):
+    """Should fail if password is not defined."""
+    probe = ElmoProbe(
+        {"base_url": "https://example.com", "vendor": "vendor", "username": "user"}
+    )
+    with caplog.at_level(logging.ERROR):
+        result = probe.run()
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "ERROR"
+        assert "missing credentials" in record.message
+        assert result is False
+
+
+def test_elmo_success(mocker):
+    """Should collect metrics using the ElmoClient."""
+    probe = ElmoProbe(
+        {
+            "base_url": "https://example.com",
+            "vendor": "vendor",
+            "username": "user",
+            "password": "pass",
+        }
+    )
+    client = mocker.patch("hal.probes.elmo.ElmoClient")
+    client().check.return_value = {
+        "areas_armed": [{"id": 0, "name": "Entryway"}],
+        "areas_disarmed": [{"id": 1, "name": "Kitchen"}],
+        "inputs_alerted": [{"id": 0, "name": "Door"}],
+        "inputs_wait": [{"id": 1, "name": "Window"}],
+    }
+    assert probe.run() is True
+    assert len(probe.results) == 2
+    assert probe.results["hal.elmo.areas"] == [
+        (1, ["name:Entryway", "status:armed"]),
+        (1, ["name:Kitchen", "status:disarmed"]),
+    ]
+    assert probe.results["hal.elmo.inputs"] == [
+        (1, ["name:Door", "status:alerted"]),
+        (1, ["name:Window", "status:wait"]),
+    ]
+
+
+def test_elmo_fail_api_calls(mocker, caplog):
+    """Should log if ElmoClient is unable to retrieve the system status."""
+    probe = ElmoProbe(
+        {
+            "base_url": "https://example.com",
+            "vendor": "vendor",
+            "username": "user",
+            "password": "pass",
+        }
+    )
+    client = mocker.patch("hal.probes.elmo.ElmoClient")
+    client().check.side_effect = mocker.Mock(side_effect=HTTPError("403"))
+    with caplog.at_level(logging.ERROR):
+        assert probe.run() is False
+        assert len(probe.results) == 0
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "ERROR"
+        assert "ElmoClient returns '403'" in record.message


### PR DESCRIPTION
### Overview

Closes #27 

* Adds https://github.com/palazzem/elmo-alerting dependency
* Leverages `ElmoClient` to retrieve the status of an Elmo system (armed/disarmed alarms, system input in alerted state)
* Exports data to Datadog