### PR TITLE
Add tagging support to Watchdog

### DIFF
--- a/functions/watchdog.py
+++ b/functions/watchdog.py
@@ -10,8 +10,9 @@ def entrypoint(event, context):
 
     Environment variables configuration:
       * `DD_API_KEY`: Datadog API key.
-      * `DD_HOSTNAME` (default `hal`): Hostname used for the Datadog metric.
-      * `WATCHDOG_HOSTS` (default `[]`): List of hostnames or IP addresses to check
+      * `DD_HOSTNAME` (default `hal`): Hostname used for the Datadog metric. It has the format:
+        `127.0.0.1|name:hal another-address|name:system`
+      * `WATCHDOG_HOSTS` (default `[]`): List of hostnames or IP addresses to check.
       * `WATCHDOG_TAGS` (default `None`): Add tags to all Datadog metrics.
 
     Args:
@@ -19,7 +20,12 @@ def entrypoint(event, context):
          context (google.cloud.functions.Context): Metadata for the event.
     """
     config = {
-        "hosts": getenv("WATCHDOG_HOSTS", "").split(),
+        # TODO: Such king of logic must be isolated in a settings system.
+        # Check: https://github.com/palazzem/hal/issues/29
+        "hosts": [
+            (y[0], y[1])
+            for y in [x.split("|") for x in getenv("WATCHDOG_HOSTS", "").split()]
+        ],
         "exporters": [
             DatadogExporter(
                 {

--- a/hal/probes/watchdog.py
+++ b/hal/probes/watchdog.py
@@ -9,9 +9,9 @@ log = logging.getLogger(__name__)
 
 class WatchdogProbe(BaseProbe):
     """WatchdogProbe Probe detects if a list of hosts are connected to the
-    probe network. This probe requires a list of hosts address:
-        * ["127.0.0.1"]
-        * ["192.168.1.1", "test-server"]
+    probe network. This probe requires a list of hosts tuples (address, tag-name):
+        * [("127.0.0.1", "palazzem")]
+        * [("192.168.1.1", "palazzem"), ("test-server", "tali")]
 
     Under the hood, `WatchdogProbe` uses `ping` sending a single packet and
     checking the return code. `subprocess` is used
@@ -28,16 +28,20 @@ class WatchdogProbe(BaseProbe):
             # Bail out if hosts are not defined
             return False, "run failed for missing hosts to monitor"
 
-        # Metric: number of detected hosts
-        self.results["hal.watchdog.detected_hosts"] = 0
+        # Dict used to aggregate results instead of extra iterations
+        detected_hosts = {}
 
         for host in self.config["hosts"]:
             # Ping the host to check if present in the network
-            process = subprocess.run(["ping", "-c", "1", host], capture_output=True)
+            address, name = host
+            process = subprocess.run(["ping", "-c", "1", address], capture_output=True)
             if process.returncode == 0:
-                self.results["hal.watchdog.detected_hosts"] += 1
+                check = detected_hosts.get(name) or (0, [name])
+                detected_hosts[name] = (check[0] + 1, check[1])
             else:
                 # Keep debug information with `ping` stdout
-                log.debug("Probe watchdog: host '%s' not found", host)
+                log.debug("Probe watchdog: host '%s' not found", address)
 
+        # Metric: number of detected hosts by tag (name)
+        self.results["hal.watchdog.detected_hosts"] = list(detected_hosts.values())
         return True, None


### PR DESCRIPTION
### Overview

The previous version of Watchdog was only counting number of connected devices. This change adds tags support so that it's possible to count the number of devices connected, or split it by name.