### PR TITLE
Add Hal containers configuration

### DIFF
--- a/hass/README.md
+++ b/hass/README.md
@@ -1,0 +1,9 @@
+# Hal Configuration
+
+Create a `.env` file as follows:
+```
+UID=1000
+GID=1000
+ACME_EMAIL=hal@example.com
+HAL_FQDN=hal.example.com
+```

--- a/hass/docker-compose.yml
+++ b/hass/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3.7'
+services:
+  traefik:
+    restart: always
+    image: "traefik:v2.2"
+    container_name: "traefik"
+    command:
+      - --api.dashboard=false
+      - --providers.docker=true
+      - --providers.file=true
+      - --providers.file.filename=/etc/traefik/rules.yaml
+      - --entryPoints.web.address=:80
+      - --entryPoints.websecure.address=:443
+      - --certificatesResolvers.le.acme.email=${ACME_EMAIL}
+      - --certificatesResolvers.le.acme.storage=/acme.json
+      - --certificatesResolvers.le.acme.tlschallenge=true
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ${PWD}/acme.json:/acme.json
+      - ${PWD}/rules.yaml:/etc/traefik/rules.yaml
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - ACME_EMAIL
+      - HAL_FQDN
+    labels:
+      # Middleware redirect
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      # Catch-all redirect to HTTPS
+      - "traefik.http.routers.redirs.rule=hostregexp(`{host:.+}`)"
+      - "traefik.http.routers.redirs.entrypoints=web"
+      - "traefik.http.routers.redirs.middlewares=redirect-to-https"
+
+  home-assistant:
+    restart: unless-stopped
+    container_name: hal
+    image: homeassistant/home-assistant:0.107.4
+    environment:
+      - TZ=Europe/Rome
+      - UID=${UID}
+      - GID=${GID}
+    volumes:
+      - ${PWD}/etc:/config
+    network_mode: host
+    labels:
+      - "traefik.enable=false"

--- a/hass/rules.yaml
+++ b/hass/rules.yaml
@@ -1,0 +1,15 @@
+http:
+  routers:
+    hal:
+      rule: Host(`{{env "HAL_FQDN"}}`)
+      tls:
+        certResolver: le
+      entrypoints:
+        - websecure
+      service: hal
+  services:
+    hal:
+      loadBalancer:
+        servers:
+          # 172.17.0.1 is the `docker0` interface
+          - url: 'http://172.17.0.1:8123'


### PR DESCRIPTION
### Overview

This PR adds Hal containers config:
* Includes a `docker-compose.yml` to launch `traefik` and `home-assistant`
* Includes a `rules.yaml` to do TLS termination with `network_mode: host` is used from Home Assistant.