### PR TITLE
Add configuration for Rattlestar System

### DIFF
--- a/hass/.gitignore
+++ b/hass/.gitignore
@@ -5,6 +5,7 @@ deps
 tts
 
 # Ensure these files are ignored to prevent a leak
+certs/
 acme.json
 ip_bans.yaml
 secrets.yaml

--- a/hass/docker-compose.yml
+++ b/hass/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
   traefik:
     restart: always
-    image: "traefik:v2.2"
+    image: traefik:v2.2
     container_name: "traefik"
     command:
       - --api.dashboard=false

--- a/hass/docker-compose.yml
+++ b/hass/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     environment:
       - ACME_EMAIL
       - HAL_FQDN
+      - RATTLESTAR_FQDN
+      - RATTLESTAR_LOCAL_FQDN
     labels:
       # Middleware redirect
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"

--- a/hass/docker-compose.yml
+++ b/hass/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - --providers.file.filename=/etc/traefik/rules.yaml
       - --entryPoints.web.address=:80
       - --entryPoints.websecure.address=:443
+      # Use Letsencrypt and an internal Root CA for self-signed certificates (mkcert)
+      - --serversTransport.rootCAs=/certs/rootCA.pem
       - --certificatesResolvers.le.acme.email=${ACME_EMAIL}
       - --certificatesResolvers.le.acme.storage=/acme.json
       - --certificatesResolvers.le.acme.tlschallenge=true
@@ -18,9 +20,11 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ${PWD}/acme.json:/acme.json
-      - ${PWD}/rules.yaml:/etc/traefik/rules.yaml
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Letsencrypt and custom Root CA certificates mounts
+      - ${PWD}/acme.json:/acme.json
+      - ${PWD}/certs/:/certs/
+      - ${PWD}/rules.yaml:/etc/traefik/rules.yaml
     environment:
       - ACME_EMAIL
       - HAL_FQDN

--- a/hass/rules.yaml
+++ b/hass/rules.yaml
@@ -1,13 +1,25 @@
 http:
   routers:
+    rattlestar:
+      service: rattlestar
+      rule: Host(`{{env "RATTLESTAR_FQDN"}}`)
+      tls:
+        certResolver: le
+      entrypoints:
+        - websecure
     hal:
+      service: hal
       rule: Host(`{{env "HAL_FQDN"}}`)
       tls:
         certResolver: le
       entrypoints:
         - websecure
-      service: hal
   services:
+    rattlestar:
+      loadBalancer:
+        servers:
+          # Reverse Proxy to another Traefik service
+          - url: 'https://{{env "RATTLESTAR_LOCAL_FQDN"}}'
     hal:
       loadBalancer:
         servers:


### PR DESCRIPTION
### Overview

Hal is the edge gateway of the system, and Traefik is reconfigured to act as main proxy. In the Internal network a [Rattlestar System](https://en.wikipedia.org/wiki/Rattlestar_Ricklactica) is exposed, and Hal will redirect the traffic to that.

Main changes:
- Support an internal Root CA to keep the communication under HTTPS
- Do reverse proxy to `rattlestar.lan`