### PR TITLE
Traefik uses Elliptic Curves (EC256)

### DIFF
--- a/hass/docker-compose.yml
+++ b/hass/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # Use Letsencrypt and an internal Root CA for self-signed certificates (mkcert)
       - --serversTransport.rootCAs=/certs/rootCA.pem
       - --certificatesResolvers.le.acme.email=${ACME_EMAIL}
+      - --certificatesResolvers.le.acme.keyType=EC256
       - --certificatesResolvers.le.acme.storage=/acme.json
       - --certificatesResolvers.le.acme.tlschallenge=true
     ports:

--- a/hass/rules.yaml
+++ b/hass/rules.yaml
@@ -25,3 +25,8 @@ http:
         servers:
           # 172.17.0.1 is the `docker0` interface
           - url: 'http://172.17.0.1:8123'
+
+tls:
+  options:
+    default:
+      minVersion: VersionTLS12


### PR DESCRIPTION
### Overview

By default, Traefik requests for a RSA4096 certificate (high-security). Unfortunately current hardware doesn't have enough CPU power to handle fast SSL negotiation, so we moved to Elliptic Curves with a 256-bit key size. That's enough to have roughly the [same security level as RSA 3072-bit](https://crypto.stackexchange.com/questions/76699/elliptic-curve-vs-rsa-key-length-comparison).

This change includes Traefik upgrade to support only TLS 1.2+

### Benchmark

```bash
# Before
$ time curl https://mydomain
0.02s user 0.01s system 4% cpu 0.613 total

# After
$ time curl https://mydomain
0.03s user 0.02s system 28% cpu 0.171 total
```