### PR TITLE
Add WebOS TV

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,6 +36,8 @@ jobs:
           echo 'home_elevation: 42' >> hass/etc/secrets.yaml
           echo 'gamestream_wol_mac: bc:1f:a0:96:a5:f3' >> hass/etc/secrets.yaml
           echo 'gamestream_wol_host: 192.168.0.1' >> hass/etc/secrets.yaml
+          echo 'tv_mac: bc:1f:a0:96:a5:f3' >> hass/etc/secrets.yaml
+          echo 'tv_host: 192.168.0.1' >> hass/etc/secrets.yaml
       
       - name: Check configuration
         run: hass -c hass/etc/ --script check_config

--- a/hass/.gitignore
+++ b/hass/.gitignore
@@ -14,6 +14,7 @@ known_devices.yaml
 service_account.json
 hosts.yaml
 zones.yaml
+webostv.conf
 
 # Logs
 *.log

--- a/hass/etc/configuration.yaml
+++ b/hass/etc/configuration.yaml
@@ -56,6 +56,14 @@ switch:
     mac: !secret gamestream_wol_mac
     host: !secret gamestream_wol_host
 
+webostv:
+  host: !secret tv_host
+  name: TV
+  turn_on_action:
+    service: wake_on_lan.send_magic_packet
+    data:
+      mac: !secret tv_mac
+
 # Export Data
 datadog:
   host: localhost

--- a/hass/etc/scenes.yaml
+++ b/hass/etc/scenes.yaml
@@ -23,23 +23,37 @@
   entities:
     light.entryway:
       friendly_name: Ingresso
-      state: 'off'
       supported_features: 0
+      state: 'off'
     light.kitchen:
       friendly_name: Cucina
-      state: 'off'
       supported_features: 0
+      state: 'off'
     light.living_room:
       friendly_name: Sala
-      state: 'off'
       supported_features: 0
+      state: 'off'
     light.tv_backlight:
       brightness: 255
       friendly_name: TV Backlight
-      state: 'on'
       supported_features: 1
+      state: 'on'
     switch.gaming_station:
       friendly_name: Gaming Station
+      state: 'on'
+    media_player.tv:
+      source_list:
+      - HDMI 1
+      - HDMI 2
+      - HDMI 3
+      - HDMI 4
+      volume_level: 0.18
+      is_volume_muted: false
+      source: HDMI 3
+      sound_output: tv_speaker
+      friendly_name: TV
+      supported_features: 20413
+      device_class: tv
       state: 'on'
 - id: '1585506531123'
   name: Dinner


### PR DESCRIPTION
### Overview

* Add `WebOS TV` entity to control the living dinner TV
* Turn on the TV when Gaming scene is triggered