### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   hal-config-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     container:
       image: python:latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     container:
-      image: python:latest
+      image: python:3.8
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Overview

Update GitHub actions:

- Ubuntu 20.04 (removes the warning, plus no specific requirements on Ubuntu version)
- Python 3.8 (Home Assistant doesn't run on Python 3.9)